### PR TITLE
refactor: set "extended" as the default tweet mode

### DIFF
--- a/iocingestor/sources/twitter.py
+++ b/iocingestor/sources/twitter.py
@@ -18,6 +18,7 @@ class Plugin(Source):
         access_token: str,
         access_token_secret: str,
         defanged_only: bool = True,
+        tweet_mode: str = "extended",
         **kwargs,
     ):
         self.name = name
@@ -33,6 +34,10 @@ class Plugin(Source):
         # Forward kwargs.
         # NOTE: No validation is done here, so if the config is wrong, expect bad results.
         self.kwargs = kwargs
+
+        # Set "extended" as the default tweet mode
+        if kwargs.get("tweet_mode") is None:
+            self.kwargs["tweet_mode"] = tweet_mode
 
         # Decide which endpoint to use based on passed arguments.
         # If slug and owner_screen_name, use List API.
@@ -69,7 +74,7 @@ class Plugin(Source):
 
         tweets = [
             {
-                "content": s["text"],
+                "content": s.get("full_text") or s.get("text"),
                 "id": s["id_str"],
                 "user": s["user"]["screen_name"],
                 "entities": s.get("entities", {}),

--- a/tests/test_sources_twitter.py
+++ b/tests/test_sources_twitter.py
@@ -48,7 +48,9 @@ class TestTwitter(unittest.TestCase):
 
     def test_run_respects_saved_state(self):
         self.twitter.run("12345")
-        self.twitter.endpoint.assert_called_once_with(since_id="12345")
+        self.twitter.endpoint.assert_called_once_with(
+            tweet_mode="extended", since_id="12345"
+        )
 
     def test_run_returns_newest_tweet_id_as_saved_state(self):
         self.twitter.endpoint.return_value = [

--- a/tests/test_sources_twitter.py
+++ b/tests/test_sources_twitter.py
@@ -93,6 +93,19 @@ class TestTwitter(unittest.TestCase):
             "https://twitter.com/test/status/12345", artifact_list[0].reference_link
         )
 
+    def test_run_returns_artifacts_correctly_with_full_text(self):
+        self.twitter.endpoint.return_value = [
+            {
+                "full_text": "hxxp://fullurl.com/test",
+                "id_str": "12345",
+                "user": {"screen_name": "test"},
+            },
+        ]
+        saved_state, artifact_list = self.twitter.run(None)
+        self.assertEqual(len(artifact_list), 3)
+        self.assertIn("fullurl.com", [str(x) for x in artifact_list])
+        self.assertIn("http://fullurl.com/test", [str(x) for x in artifact_list])
+
     def test_run_expands_tco_links_if_available(self):
         self.twitter.endpoint.return_value = [
             {


### PR DESCRIPTION
Set "extended" as the default tweet mode to get a content exactly